### PR TITLE
"tag" and "preview" links

### DIFF
--- a/standard/clause_5_conventions.adoc
+++ b/standard/clause_5_conventions.adoc
@@ -1,14 +1,64 @@
 == Conventions
-This section provides details and examples for any conventions used in the document. Examples of conventions are symbols, abbreviations, use of XML schema, or special notes regarding how to read the document.
-
-#TODO: add information about the use of OpenAPI 3.0, link relation types, etc.#
 
 === Identifiers
+
 The normative provisions in this draft specification are denoted by the URI
 
 http://www.opengis.net/spec/ogcpapi-styles-1/1.0
 
 All requirements and conformance tests that appear in this document are denoted by partial URIs which are relative to this base.
+
+=== Link relations
+
+To express relationships between resources, <<rfc8288,RFC 8288 (Web Linking)>> is used.
+
+The following link relation types registered with IANA are used in this document:
+
+* **alternate**: Refers to a substitute for this context.
+* **collection**: The target IRI points to a resource which represents the collection resource for the context IRI.
+* **describedby**: Refers to a resource providing information about the link's context.
+* **enclosure**: Identifies a related resource that is potentially large and might require special handling.
+* **preview**: Refers to a resource that provides a preview of the link's context.
+* **self**: Conveys an identifier for the link's context.
+* **service-desc**: Identifies service description for the context that is primarily intended for consumption by machines.
+* **service-doc**: Identifies service documentation for the context that is primarily intended for human consumption.
+* **start**: Refers to the first resource in a collection of resources.
+* **stylesheet**: Refers to a stylesheet.
+
+The following link relation types registered with the OGC Naming Authority are used in this document:
+
+* **\http://www.opengis.net/def/rel/ogc/1.0/conformance**: Refers to resource that identifies the specifications that the link’s context conforms to.
+* **\http://www.opengis.net/def/rel/ogc/1.0/tilesets-vector**: The target IRI points to a resource that describes how to provide tile sets of the context resource in vector format.
+* **\http://www.opengis.net/def/rel/ogc/1.0/tileset-coverage**: The target IRI points to a resource that describes how to provide tile sets of the context resource in coverage format.
+
+The following link relation types will be registered with the OGC Naming Authority, if the document is approved:
+
+* **\http://www.opengis.net/def/rel/ogc/1.0/schema**: Refers to a schema that data has to conform to to be suitable for use with the link's context.
+* **\http://www.opengis.net/def/rel/ogc/1.0/styles**: Refers to a collection of styles.
+
+Each resource representation includes an array of links. Implementations are free to add additional links for all resources provided by the API.
+
+=== Use of HTTPS
+
+For simplicity, this document in general only refers to the HTTP protocol. This is not meant to exclude the use of HTTPS and simply is a shorthand notation for "HTTP or HTTPS." In fact, most servers are expected to use HTTPS, not HTTP.
+
+=== References to OpenAPI components in normative statements
+
+This document uses OpenAPI 3.0 fragments as examples and to formally state requirements. However, using OpenAPI 3.0 is not required for implementing a server.
+
+In this document, fragments of OpenAPI definitions are shown in YAML (YAML Ain't Markup Language) since YAML is easier to read than JSON and is typically used in OpenAPI editors. YAML is described by its authors as a human friendly data serialization standard for all programming languages.
+
+Some normative statements (requirements, recommendations and permissions) use a phrase that a component in the API definition of the server must be "based upon" a schema or parameter component in the OGC schema repository.
+
+In the case above, the following changes to the pre-defined OpenAPI component are permitted.
+
+* The range of values of a parameter or property may be extended (additional values) or constrained (if a subset of all possible values are applicable to the server). An example for a constrained range of values is to explicitly specify the supported values of a string parameter or property using an enum.
+* The default value of a parameter may be changed or added unless a requirement explicitly prohibits this.
+* Additional properties may be added to the schema definition of a Response Object.
+* Informative text may be changed or added, like comments or description properties.
+* If the server supports an XML encoding, `xml` properties may be added to the relevant OpenAPI schema components.
+
+For API definitions that do not conform to the OpenAPI Specification 3.0, the normative statement should be interpreted in the context of the API definition language used.
 
 ===	Abbreviated terms
 

--- a/standard/clause_7_styles-api.adoc
+++ b/standard/clause_7_styles-api.adoc
@@ -203,9 +203,11 @@ properties:
 ^|E |Each style SHALL have at least one link to a style encoding supported for the style (link relation type: `stylesheet`) with the `type` attribute stating the media type of the style encoding.
 ^|F |Each style SHALL have a link to the style metadata (link relation type: `describedby`) with the `type` attribute stating the media type of the metadata encoding.
 ^|G |The `default` member SHALL, if provided, be the `id` of one of the styles in the `styles` array.
+^|H |If a `tag` link to a URI for the schema of the data is available for a style in the style metadata (see <<rec_core_style-md-tag>>), a link with the link relation type `tag` SHALL also be provided in the Styles resource.
+^|I |If a thumbnail is available for a style in the style metadata (see <<rec_core_style-md-preview>>), a link with the link relation type `preview` SHALL also be provided in the Styles resource. 
 |===
 
-#TODO: Currently the links to the thumbnails of a style are available only as part of the style metadata (see <<rec_core_style-md-preview,recommendation "/rec/core/style-md-preview">>). To display an overview of the styles with a thumbnail image, a client needs to send multiple requests, the first one for the list of styles and then a request for each style metadata to get the thumbnail links. Whether the preview should also be included for each style in the Styles resource should be discussed.#
+The `tag` and `preview` links are also part of the style metadata. If available, they have to be included for a style in the Styles resource, too, so that clients have access to this information without the need to send requests for all style metadata resources.
 
 [[rec_core_style-title]]
 [width="90%",cols="2,6a"]
@@ -240,6 +242,15 @@ properties:
           "href": "https://example.com/api/v1/styles/night/metadata?f=json",
           "type": "application/json",
           "rel": "describedby"
+        },
+        {
+          "href": "https://registry.example.com/data/schemas/tds/6.1",
+          "rel": "tag"
+        },
+        {
+          "href": "https://example.com/api/v1/resources/night-thumbnail.png",
+          "type": "image/png",
+          "rel": "preview"
         }
       ]
     },
@@ -261,6 +272,15 @@ properties:
           "href": "https://example.com/api/v1/styles/topographic/metadata?f=json",
           "type": "application/json",
           "rel": "describedby"
+        },
+        {
+          "href": "https://registry.example.com/data/schemas/tds/6.1",
+          "rel": "tag"
+        },
+        {
+          "href": "https://example.com/api/v1/resources/topographic-thumbnail.png",
+          "type": "image/png",
+          "rel": "preview"
         }
       ]
     }
@@ -459,6 +479,19 @@ properties:
 
 #TODO: Add guidance for links to coverage data?#
 
+[[rec_core_style-md-tag]]
+[width="90%",cols="2,6a"]
+|===
+^|*Recommendation {counter:rec-id}* |*/rec/core/style-md-tag*
+^|A |If a style can be used to style multiple geospatial datasets that implement a common schema and where a canonical URI exists for the schema, a link with the link relation type `tag` SHOULD be provided. 
+|===
+
+The `tag` links indicate to clients that the style is suitable for styling any dataset distribution that conforms to the schema identified by the target URI.
+
+Clients that are familiar with the schema that is identified in a `tag` link will in general have no need for the information in the `layers` member, because the layer.
+
+NOTE: It has been proposed to register URIs for commonly used schemas in the http://www.opengis.net/def[OGC Definition Server].
+
 [[rec_core_style-md-preview]]
 [width="90%",cols="2,6a"]
 |===
@@ -554,6 +587,10 @@ The thumbnail may be an image that is published as a resource in the API. The th
       "rel": "preview",
       "type": "image/png",
       "title": "thumbnail of the night style applied to OSM data from Daraa, Syria"
+    },
+    {
+      "href": "https://registry.example.com/data/schemas/tds/6.1",
+      "rel": "tag"
     }
   ]
 }

--- a/standard/clause_7_styles-api.adoc
+++ b/standard/clause_7_styles-api.adoc
@@ -203,11 +203,11 @@ properties:
 ^|E |Each style SHALL have at least one link to a style encoding supported for the style (link relation type: `stylesheet`) with the `type` attribute stating the media type of the style encoding.
 ^|F |Each style SHALL have a link to the style metadata (link relation type: `describedby`) with the `type` attribute stating the media type of the metadata encoding.
 ^|G |The `default` member SHALL, if provided, be the `id` of one of the styles in the `styles` array.
-^|H |If a `tag` link to a URI for the schema of the data is available for a style in the style metadata (see <<rec_core_style-md-tag>>), a link with the link relation type `tag` SHALL also be provided in the Styles resource.
+^|H |If a `\http://www.opengis.net/def/rel/ogc/1.0/schema` link to a URI for the schema of the data is available for a style in the style metadata (see <<rec_core_style-md-schema>>), a link with the same link relation type SHALL also be provided in the Styles resource.
 ^|I |If a thumbnail is available for a style in the style metadata (see <<rec_core_style-md-preview>>), a link with the link relation type `preview` SHALL also be provided in the Styles resource. 
 |===
 
-The `tag` and `preview` links are also part of the style metadata. If available, they have to be included for a style in the Styles resource, too, so that clients have access to this information without the need to send requests for all style metadata resources.
+The `\http://www.opengis.net/def/rel/ogc/1.0/schema` and `preview` links are also part of the style metadata. If available, they have to be included for a style in the Styles resource, too, so that clients have access to this information without the need to send requests for all style metadata resources.
 
 [[rec_core_style-title]]
 [width="90%",cols="2,6a"]
@@ -245,7 +245,8 @@ The `tag` and `preview` links are also part of the style metadata. If available,
         },
         {
           "href": "https://registry.example.com/data/schemas/tds/6.1",
-          "rel": "tag"
+          "type": "application/json",
+          "rel": "http://www.opengis.net/def/rel/ogc/1.0/schema"
         },
         {
           "href": "https://example.com/api/v1/resources/night-thumbnail.png",
@@ -275,7 +276,8 @@ The `tag` and `preview` links are also part of the style metadata. If available,
         },
         {
           "href": "https://registry.example.com/data/schemas/tds/6.1",
-          "rel": "tag"
+          "type": "application/json",
+          "rel": "http://www.opengis.net/def/rel/ogc/1.0/schema"
         },
         {
           "href": "https://example.com/api/v1/resources/topographic-thumbnail.png",
@@ -474,23 +476,24 @@ properties:
 * `enclosure` for links to sample data that may be downloaded (e.g. a GeoPackage);
 * `collection` for links to a Collection resource according to OGC API Common (e.g. `/collections/{collectionId}`; the collection may be available as features (tiled or not) or as gridded data);
 * `start` for links to a Features resource according to OGC API Features (e.g. `/collections/{collectionId}/items`; the response may contain a `next` link to additional features);
-* `http://www.opengis.net/def/rel/ogc/1.0/tiles` for a link to a Tile Sets resource (e.g. `/collections/{collectionId}/tiles`).
+* `\http://www.opengis.net/def/rel/ogc/1.0/tilesets-vector` for a link to a Tile Sets resource (e.g. `/collections/{collectionId}/tiles`) with vector tiles.
+* `\http://www.opengis.net/def/rel/ogc/1.0/tilesets-coverage` for a link to a Tile Sets resource (e.g. `/collections/{collectionId}/tiles`) with coverage tiles.
 |===
 
 #TODO: Add guidance for links to coverage data?#
 
-[[rec_core_style-md-tag]]
+[[rec_core_style-md-schema]]
 [width="90%",cols="2,6a"]
 |===
-^|*Recommendation {counter:rec-id}* |*/rec/core/style-md-tag*
-^|A |If a style can be used to style multiple geospatial datasets that implement a common schema and where a canonical URI exists for the schema, a link with the link relation type `tag` SHOULD be provided. 
+^|*Recommendation {counter:rec-id}* |*/rec/core/style-md-schema*
+^|A |If a style can be used to style multiple geospatial datasets that implement a common schema and where a canonical URI exists for the schema, a link with the link relation type `\http://www.opengis.net/def/rel/ogc/1.0/schema` SHOULD be provided. 
 |===
 
-The `tag` links indicate to clients that the style is suitable for styling any dataset distribution that conforms to the schema identified by the target URI.
+The schema links indicate to clients that the style is suitable for styling any dataset distribution that conforms to the schema identified by the target URI.
 
-Clients that are familiar with the schema that is identified in a `tag` link will in general have no need for the information in the `layers` member, because the layer.
+Clients that are familiar with the schema that is identified in a schema link will in general have no need for the information in the `layers` member, because they already "know" the layers in the schema and their properties.
 
-NOTE: It has been proposed to register URIs for commonly used schemas in the http://www.opengis.net/def[OGC Definition Server].
+NOTE: It has been proposed to register URIs for commonly used schemas in the http://www.opengis.net/def[OGC Definition Server]. The target URIs, if dereferenced, should provide the content of the "layer" member as defined in the style metadata schema.
 
 [[rec_core_style-md-preview]]
 [width="90%",cols="2,6a"]
@@ -590,7 +593,8 @@ The thumbnail may be an image that is published as a resource in the API. The th
     },
     {
       "href": "https://registry.example.com/data/schemas/tds/6.1",
-      "rel": "tag"
+      "type": "application/json",
+      "rel": "http://www.opengis.net/def/rel/ogc/1.0/schema"
     }
   ]
 }


### PR DESCRIPTION
This PR adds the capability to tag a style with the schema or schemas that are supported by the style. The stylesheets can be used to style any dataset distribution that conforms to the identified schema. This implements the "stylable layer set" concept.

The tag is provided on the Styles and Style Metadata resources.

The thumbnail information has been added to the Styles resources, too.

closes #13