### PR TITLE
Clause 7 - Styles API: Attempt to clarify NamedLayer vs. FeatureTypeN…

### DIFF
--- a/standard/clause_7_styles-api.adoc
+++ b/standard/clause_7_styles-api.adoc
@@ -20,7 +20,7 @@ Typical base resources are:
 
 === Resources referenced from styles
 
-Stylesheets often reference external resources, especially symbols and fonts to be used in the rendering process. Symbols are either managed as a single file for each symbol or they are organized in a sprite. In a sprite, all symbols are combined into a single bitmap image to reduce memory and the number of http requests. 
+Stylesheets often reference external resources, especially symbols and fonts to be used in the rendering process. Symbols are either managed as a single file for each symbol or they are organized in a sprite. In a sprite, all symbols are combined into a single bitmap image to reduce memory and the number of http requests.
 
 Since these resources are referenced from stylesheets using a URI of the resource, the details where and how the resources are hosted are not important and this specification does not specify API building blocks for publishing such resources.
 
@@ -220,7 +220,7 @@ properties:
 [source,JSON]
 ----
 {
-  "default": "topographic", 
+  "default": "topographic",
   "styles": [
     {
       "id": "night",
@@ -402,7 +402,7 @@ properties:
       properties:
         id:
           type: string
-          title: Identifier 
+          title: Identifier
           description: a layer id, typically the same identifier used in the style to refer to the layer
         description:
           type: string
@@ -644,7 +644,7 @@ A value `null` will remove the `default` member, i.e., there is no default style
 [[replace_style]]
 ==== Replace a style
 
-#TODO: There are two options how to handle PUT on `{baseResource}/styles/{styleId}`, depending on whether the server supports automated derivation of stylesheets in other style encodings.# 
+#TODO: There are two options how to handle PUT on `{baseResource}/styles/{styleId}`, depending on whether the server supports automated derivation of stylesheets in other style encodings.#
 
 #1. The PUT request removes all existing stylesheets of the style. The submitted stylesheet is accepted as the new style definition. If the server supports automatic derivation of stylesheets in other style encodings, it will derive other stylesheets from the new style definition and add them to the style metadata.#
 
@@ -1051,21 +1051,19 @@ The content of a stylesheet document will typically depend on the `{baseResource
 [width="90%",cols="2,6a"]
 |===
 ^|*Requirement {counter:req-id}* |*/req/sld10/content*
-^|A |If `{baseResource}` is a Landing Page of an API that publishes a dataset (i.e., it includes a Collections resource at `/collections`), the document SHALL contain one or more `NamedLayer` elements with names corresponding to collection ids, each with at least one `UserStyle`.
-^|B |If `{baseResource}` is a Collection, the document SHALL contain one `NamedLayer` element with the name corresponding to the collection id with at least one `UserStyle`.
-^|C |If `{baseResource}` is a Landing Page of an API that publishes no dataset (i.e., it includes no Collections resource at `/collections`), the document SHALL contain one or more `NamedLayer` or `UserLayer` elements, each with at least one `UserStyle`.
+^|A |The document SHALL contain one or more `NamedLayer` or `UserLayer` elements, each with at least one `UserStyle`.
+^|B |If `{baseResource}` is a Collection or Landing Page of an API that publishes a dataset (i.e., it includes a Collections resource at `/collections`), names corresponding to collection ids SHALL be specified as the `FeatureTypeName` of a `FeatureTypeStyle` (for a feature collection) or as the `CoverageName` of a `CoverageStyle` (for a coverage), and/or as the `Name` of a NamedLayer (for compatibility with this alternate approach to associate styles with collections).
 |===
 
 [[rec_sld10_style-names]]
 [width="90%",cols="2,6a"]
 |===
 ^|*Recommendation {counter:rec-id}* |*/rec/sld10/style-names*
-^|A |If a `UserStyle` has a name, it SHOULD correspond to the style id (but the name is not relevant for the processing of the style).
-^|B |If a `UserStyle` has `FeatureTypeStyle` elements with a name, the name SHOULD correspond to the collection id.
-^|C |If a `NamedLayer` has a `Name` and a `FeatureTypeStyle` with a `FeatureTypeName`, both SHOULD be consistent. 
+^|A |If a `UserStyle` has a name, it SHOULD correspond to the style id. The name is not relevant for the processing of the style, but may be assigned as the style id when posting a new style.
+^|B |The `UserStyle` SHOULD contain a `FeatureTypeStyle` element with a `FeatureTypeName`, or `CoverageStyle` element with a `CoverageName` corresponding to the collection id.
 |===
 
-In the case of a `NamedLayer` with a `Name` and a `FeatureTypeStyle` with a `FeatureTypeName`, clients should be prepared to understand either of them, with the more specific `FeatureTypeName` taking priority (as in some cases the `Name` of the `NamedLayer` may refer to a particular symbolization, e.g. casing or center line).
+In the case of a `NamedLayer` with both a `Name` and a `FeatureTypeStyle` with a `FeatureTypeName` (or a `CoverageStyle` with a `CoverageName`), clients should be prepared to understand either of them, with the more specific `FeatureTypeName` or `CoverageName` taking priority (as in some cases the `Name` of the `NamedLayer` may refer to a particular symbolization, e.g. casing or center line).
 
 If there are multiple `UserStyle` elements in a layer, clients should use the style with a name that matches the style id, if there is one. Otherwise they should pick any of the styles.
 


### PR DESCRIPTION
…ame/CoverageName requirements and recommendations

- At the previous commit, there was a contradiction that NamedLayer name could be symbolization layer name, but a requirement that is must be the collection ID
- The requirement now accepts either NamedLayer Name or FeatureTypeName/CoverageName as collection id
- The recommendartion is that FeatureTypeName/CoverageName be the collection id
- Removed the recommendation that NamedLayer Name and FeatureTypeName/CoverageName be consistent as it is contradictory with the recognition that the
  NamedLayer name could be symbolization layer name
- Keeping the note that clients should be prepared to treat NamedLayer name as collection id if no FeatureTypeName/CoverageName is present